### PR TITLE
feat(domain): 지갑 원장 도메인 모델 및 BaseEntity 추가

### DIFF
--- a/src/main/java/com/example/walletledger/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/walletledger/domain/common/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.example.walletledger.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/domain/ledger/LedgerEntry.java
+++ b/src/main/java/com/example/walletledger/domain/ledger/LedgerEntry.java
@@ -1,0 +1,64 @@
+package com.example.walletledger.domain.ledger;
+
+import com.example.walletledger.domain.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "ledger_entries")
+public class LedgerEntry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "wallet_id", nullable = false)
+    private Long walletId;
+
+    @Column(name = "transaction_id", nullable = false)
+    private Long transactionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private LedgerEntryType type;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal amount;
+
+    @Column(name = "balance_after", nullable = false, precision = 19, scale = 4)
+    private BigDecimal balanceAfter;
+
+    @Column(length = 500)
+    private String description;
+
+    protected LedgerEntry() {
+    }
+
+    private LedgerEntry(Long walletId, Long transactionId, LedgerEntryType type,
+                        BigDecimal amount, BigDecimal balanceAfter, String description) {
+        this.walletId = walletId;
+        this.transactionId = transactionId;
+        this.type = type;
+        this.amount = amount;
+        this.balanceAfter = balanceAfter;
+        this.description = description;
+    }
+
+    public static LedgerEntry credit(Long walletId, Long transactionId, BigDecimal amount,
+                                     BigDecimal balanceAfter, String description) {
+        return new LedgerEntry(walletId, transactionId, LedgerEntryType.CREDIT, amount, balanceAfter, description);
+    }
+
+    public static LedgerEntry debit(Long walletId, Long transactionId, BigDecimal amount,
+                                    BigDecimal balanceAfter, String description) {
+        return new LedgerEntry(walletId, transactionId, LedgerEntryType.DEBIT, amount, balanceAfter, description);
+    }
+}
+

--- a/src/main/java/com/example/walletledger/domain/ledger/LedgerEntryType.java
+++ b/src/main/java/com/example/walletledger/domain/ledger/LedgerEntryType.java
@@ -1,0 +1,7 @@
+package com.example.walletledger.domain.ledger;
+
+public enum LedgerEntryType {
+    CREDIT,
+    DEBIT
+}
+

--- a/src/main/java/com/example/walletledger/domain/member/Member.java
+++ b/src/main/java/com/example/walletledger/domain/member/Member.java
@@ -1,0 +1,56 @@
+package com.example.walletledger.domain.member;
+
+import com.example.walletledger.domain.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "members")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberStatus status = MemberStatus.ACTIVE;
+
+    protected Member() {
+    }
+
+    public Member(String username, String email) {
+        this.username = username;
+        this.email = email;
+        this.status = MemberStatus.ACTIVE;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public MemberStatus getStatus() {
+        return status;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/domain/member/MemberStatus.java
+++ b/src/main/java/com/example/walletledger/domain/member/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.example.walletledger.domain.member;
+
+public enum MemberStatus {
+    ACTIVE,
+    SUSPENDED
+}
+

--- a/src/main/java/com/example/walletledger/domain/transaction/TransactionStatus.java
+++ b/src/main/java/com/example/walletledger/domain/transaction/TransactionStatus.java
@@ -1,0 +1,8 @@
+package com.example.walletledger.domain.transaction;
+
+public enum TransactionStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}
+

--- a/src/main/java/com/example/walletledger/domain/transaction/TransactionType.java
+++ b/src/main/java/com/example/walletledger/domain/transaction/TransactionType.java
@@ -1,0 +1,8 @@
+package com.example.walletledger.domain.transaction;
+
+public enum TransactionType {
+    DEPOSIT,
+    WITHDRAW,
+    TRANSFER
+}
+

--- a/src/main/java/com/example/walletledger/domain/transaction/WalletTransaction.java
+++ b/src/main/java/com/example/walletledger/domain/transaction/WalletTransaction.java
@@ -1,0 +1,74 @@
+package com.example.walletledger.domain.transaction;
+
+import com.example.walletledger.domain.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "transactions")
+public class WalletTransaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "idempotency_key", nullable = false, unique = true, length = 100)
+    private String idempotencyKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private TransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionStatus status;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    protected WalletTransaction() {
+    }
+
+    private WalletTransaction(String idempotencyKey, TransactionType type) {
+        this.idempotencyKey = idempotencyKey;
+        this.type = type;
+        this.status = TransactionStatus.PENDING;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public static WalletTransaction start(String idempotencyKey, TransactionType type) {
+        return new WalletTransaction(idempotencyKey, type);
+    }
+
+    public void complete() {
+        this.status = TransactionStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public TransactionStatus getStatus() {
+        return status;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/domain/wallet/Wallet.java
+++ b/src/main/java/com/example/walletledger/domain/wallet/Wallet.java
@@ -1,0 +1,107 @@
+package com.example.walletledger.domain.wallet;
+
+import com.example.walletledger.domain.common.BaseEntity;
+import com.example.walletledger.exception.ErrorCode;
+import com.example.walletledger.exception.WalletBusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "wallets")
+public class Wallet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal balance;
+
+    @Column(nullable = false, length = 10)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WalletStatus status;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    protected Wallet() {
+    }
+
+    private Wallet(Long memberId, String currency) {
+        this.memberId = memberId;
+        this.currency = currency;
+        this.balance = BigDecimal.ZERO;
+        this.status = WalletStatus.ACTIVE;
+    }
+
+    public static Wallet create(Long memberId, String currency) {
+        return new Wallet(memberId, currency);
+    }
+
+    public void deposit(BigDecimal amount) {
+        validateActive();
+        validateAmount(amount);
+        this.balance = this.balance.add(amount);
+    }
+
+    public void withdraw(BigDecimal amount) {
+        validateActive();
+        validateAmount(amount);
+        if (this.balance.compareTo(amount) < 0) {
+            throw new WalletBusinessException(ErrorCode.INSUFFICIENT_BALANCE, "출금 가능한 잔액이 부족합니다.");
+        }
+        this.balance = this.balance.subtract(amount);
+    }
+
+    public void freeze() {
+        this.status = WalletStatus.FROZEN;
+    }
+
+    private void validateActive() {
+        if (this.status != WalletStatus.ACTIVE) {
+            throw new WalletBusinessException(ErrorCode.WALLET_NOT_ACTIVE, "비활성 지갑에서는 거래를 처리할 수 없습니다.");
+        }
+    }
+
+    private void validateAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new WalletBusinessException(ErrorCode.INVALID_AMOUNT, "거래 금액은 0보다 커야 합니다.");
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public BigDecimal getBalance() {
+        return balance;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public WalletStatus getStatus() {
+        return status;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/domain/wallet/WalletStatus.java
+++ b/src/main/java/com/example/walletledger/domain/wallet/WalletStatus.java
@@ -1,0 +1,7 @@
+package com.example.walletledger.domain.wallet;
+
+public enum WalletStatus {
+    ACTIVE,
+    FROZEN
+}
+


### PR DESCRIPTION
## 제목
<!-- 예: feat(service): 지갑 생성/입금/출금/이체 핵심 서비스 구현 -->

## 변경 목적
<!-- 이 PR이 왜 필요한지 2~4줄로 작성 -->
- Wallet Ledger 핵심 도메인 모델을 명시적으로 정의한다.
- 잔액 검증/상태 검증 로직을 엔티티에 배치해 도메인 응집도를 높인다.

## 주요 변경사항
<!-- 핵심 변경을 불릿으로 -->
- `BaseEntity`(createdAt/updatedAt) 추가
- `Member`, `Wallet`, `WalletTransaction`, `LedgerEntry` 엔티티 추가
- `WalletStatus`, `TransactionType`, `TransactionStatus`, `LedgerEntryType` 등 enum 추가
- `Wallet.deposit/withdraw` 도메인 검증 로직 구현

## 설계/구현 포인트
<!-- 면접/포트폴리오에서 설명 가능한 의사결정 위주 -->
- 트랜잭션 경계: 도메인 로직은 상태 전이만 담당, 경계는 서비스 계층에서 통제
- 동시성 제어: `Wallet.version`으로 낙관적 락 확장 여지 확보
- 데이터 정합성: 금액/상태 검증을 도메인 메서드에서 1차 차단
- 예외 처리 전략: 도메인 위반 시 `WalletBusinessException` 사용 예정
- 확장 고려사항: 거래 타입/상태 enum 확장 가능 구조

## API/스키마 영향도
- [ ] API 스펙 변경 있음
- [ ] DB 스키마 변경 있음
- [x] 없음

### 테스트 결과 요약
<!-- 실제로 확인한 결과를 짧게 -->
- 도메인 모델 컴파일 기준 정합성 점검

## 리뷰 포인트
<!-- 리뷰어가 특히 봐야 할 부분 -->
- 도메인 객체 책임 분리가 적절한지
- `Wallet`의 상태 전이/검증 로직 위치가 올바른지

## 체크리스트
- [x] 커밋 메시지를 컨벤션(`feat/chore/fix`)에 맞췄다
- [x] 비즈니스 로직이 Controller가 아닌 Service/Domain에 위치한다
- [x] 예외 코드/메시지가 일관된다
- [x] 주석(JavaDoc/인라인)은 한국어로 작성했다
- [x] 민감정보(비밀번호/키) 하드코딩이 없다
- [x] 문서(README/API 설명) 반영이 필요하면 반영했다

## 관련 이슈
<!-- 예: closes #12 -->
- 
