### PR TITLE
feat(repository): 도메인 리포지토리 및 지갑 비관적 락 조회 추가

### DIFF
--- a/src/main/java/com/example/walletledger/repository/LedgerEntryRepository.java
+++ b/src/main/java/com/example/walletledger/repository/LedgerEntryRepository.java
@@ -1,0 +1,8 @@
+package com.example.walletledger.repository;
+
+import com.example.walletledger.domain.ledger.LedgerEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LedgerEntryRepository extends JpaRepository<LedgerEntry, Long> {
+}
+

--- a/src/main/java/com/example/walletledger/repository/MemberRepository.java
+++ b/src/main/java/com/example/walletledger/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.example.walletledger.repository;
+
+import com.example.walletledger.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}
+

--- a/src/main/java/com/example/walletledger/repository/TransactionRepository.java
+++ b/src/main/java/com/example/walletledger/repository/TransactionRepository.java
@@ -1,0 +1,10 @@
+package com.example.walletledger.repository;
+
+import com.example.walletledger.domain.transaction.WalletTransaction;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<WalletTransaction, Long> {
+    Optional<WalletTransaction> findByIdempotencyKey(String idempotencyKey);
+}
+

--- a/src/main/java/com/example/walletledger/repository/WalletRepository.java
+++ b/src/main/java/com/example/walletledger/repository/WalletRepository.java
@@ -1,0 +1,17 @@
+package com.example.walletledger.repository;
+
+import com.example.walletledger.domain.wallet.Wallet;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select w from Wallet w where w.id = :walletId")
+    Optional<Wallet> findByIdForUpdate(@Param("walletId") Long walletId);
+}
+


### PR DESCRIPTION
## 제목
<!-- 예: feat(service): 지갑 생성/입금/출금/이체 핵심 서비스 구현 -->

## 변경 목적
<!-- 이 PR이 왜 필요한지 2~4줄로 작성 -->
- 서비스 계층에서 사용할 영속성 인터페이스를 정의한다.
- 출금/이체 동시성 제어를 위한 비관적 락 조회 메서드를 제공한다.

## 주요 변경사항
<!-- 핵심 변경을 불릿으로 -->
- `MemberRepository`, `WalletRepository`, `TransactionRepository`, `LedgerEntryRepository` 추가
- `WalletRepository.findByIdForUpdate()`에 `PESSIMISTIC_WRITE` 락 적용
- `TransactionRepository.findByIdempotencyKey()` 추가

## 설계/구현 포인트
<!-- 면접/포트폴리오에서 설명 가능한 의사결정 위주 -->
- 트랜잭션 경계: 락은 활성 트랜잭션 내에서만 의미가 있으므로 서비스 `@Transactional` 전제
- 동시성 제어: 동일 지갑 동시 수정 시 직렬화 처리로 race condition 완화
- 데이터 정합성: 락 + 단일 트랜잭션 조합을 통해 원자성 보장 기반 마련
- 예외 처리 전략: 리포지토리 결과 부재 시 서비스에서 도메인 예외 변환

## API/스키마 영향도
- [ ] API 스펙 변경 있음
- [ ] DB 스키마 변경 있음
- [x] 없음

### 테스트 결과 요약
<!-- 실제로 확인한 결과를 짧게 -->
- 리포지토리 인터페이스 및 락 쿼리 선언 검토 완료

## 리뷰 포인트
<!-- 리뷰어가 특히 봐야 할 부분 -->
- 락 모드 선택(`PESSIMISTIC_WRITE`) 적절성
- 멱등 키 조회 메서드 명세의 사용성

## 체크리스트
- [x] 커밋 메시지를 컨벤션(`feat/chore/fix`)에 맞췄다
- [x] 비즈니스 로직이 Controller가 아닌 Service/Domain에 위치한다
- [x] 예외 코드/메시지가 일관된다
- [x] 주석(JavaDoc/인라인)은 한국어로 작성했다
- [x] 민감정보(비밀번호/키) 하드코딩이 없다
- [x] 문서(README/API 설명) 반영이 필요하면 반영했다

## 관련 이슈
<!-- 예: closes #12 -->
- 
