### PR TITLE
feat(exception): 도메인 예외 체계와 글로벌 예외 처리기 추가

### DIFF
--- a/src/main/java/com/example/walletledger/exception/ErrorCode.java
+++ b/src/main/java/com/example/walletledger/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.example.walletledger.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "지갑을 찾을 수 없습니다."),
+    WALLET_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "활성 상태 지갑이 아닙니다."),
+    INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 금액입니다."),
+    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
+    SAME_WALLET_TRANSFER(HttpStatus.BAD_REQUEST, "동일 지갑으로 이체할 수 없습니다."),
+    IDEMPOTENCY_KEY_CONFLICT(HttpStatus.CONFLICT, "이미 처리된 멱등 키입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String defaultMessage;
+
+    ErrorCode(HttpStatus httpStatus, String defaultMessage) {
+        this.httpStatus = httpStatus;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/exception/ErrorResponse.java
+++ b/src/main/java/com/example/walletledger/exception/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.example.walletledger.exception;
+
+import java.time.Instant;
+
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final Instant timestamp;
+
+    public ErrorResponse(String code, String message, Instant timestamp) {
+        this.code = code;
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.name(), message, Instant.now());
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}
+

--- a/src/main/java/com/example/walletledger/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/walletledger/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.example.walletledger.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(WalletBusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(WalletBusinessException ex) {
+        return ResponseEntity
+            .status(ex.getErrorCode().getHttpStatus())
+            .body(ErrorResponse.of(ex.getErrorCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknownException(Exception ex) {
+        return ResponseEntity
+            .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+            .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getDefaultMessage()));
+    }
+}
+

--- a/src/main/java/com/example/walletledger/exception/WalletBusinessException.java
+++ b/src/main/java/com/example/walletledger/exception/WalletBusinessException.java
@@ -1,0 +1,21 @@
+package com.example.walletledger.exception;
+
+public class WalletBusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public WalletBusinessException(ErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+    }
+
+    public WalletBusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}
+


### PR DESCRIPTION
## 제목
<!-- 예: feat(service): 지갑 생성/입금/출금/이체 핵심 서비스 구현 -->

## 변경 목적
<!-- 이 PR이 왜 필요한지 2~4줄로 작성 -->
- 비즈니스 예외를 일관된 코드/메시지로 응답하기 위한 기반을 만든다.
- 컨트롤러 중복 try-catch 없이 전역 처리로 API 응답 일관성을 확보한다.

## 주요 변경사항
<!-- 핵심 변경을 불릿으로 -->
- `ErrorCode` enum 추가 (HTTP Status + 기본 메시지)
- `WalletBusinessException` 추가
- `ErrorResponse` DTO 추가
- `GlobalExceptionHandler`(`@RestControllerAdvice`) 추가

## 설계/구현 포인트
<!-- 면접/포트폴리오에서 설명 가능한 의사결정 위주 -->
- 트랜잭션 경계: 예외 발생 시 트랜잭션 롤백 기본 동작 활용
- 동시성 제어: 동시성 충돌 결과도 도메인 예외로 표준화 가능
- 데이터 정합성: 실패를 명확히 표현해 상위 계층 재처리/관측 용이성 확보
- 예외 처리 전략: known exception(비즈니스) / unknown exception(500) 분리

## API/스키마 영향도
- [x] API 스펙 변경 있음
- [ ] DB 스키마 변경 있음
- [ ] 없음

### API 변경 내용
<!-- 엔드포인트 추가/변경/삭제 요약 -->
- 에러 응답 포맷 표준화 (`code`, `message`, `timestamp`)

### 테스트 결과 요약
<!-- 실제로 확인한 결과를 짧게 -->
- 예외 매핑 정책 정적 검토 완료

## 리뷰 포인트
<!-- 리뷰어가 특히 봐야 할 부분 -->
- 에러 코드 분류 체계가 충분한지
- 클라이언트 관점에서 메시지/상태코드 일관성

## 체크리스트
- [x] 커밋 메시지를 컨벤션(`feat/chore/fix`)에 맞췄다
- [x] 비즈니스 로직이 Controller가 아닌 Service/Domain에 위치한다
- [x] 예외 코드/메시지가 일관된다
- [x] 주석(JavaDoc/인라인)은 한국어로 작성했다
- [x] 민감정보(비밀번호/키) 하드코딩이 없다
- [x] 문서(README/API 설명) 반영이 필요하면 반영했다

## 관련 이슈
<!-- 예: closes #12 -->
- 
