### PR TITLE
feat(api): 지갑 명령 API와 Redis 멱등성 인프라 스켈레톤 추가

### DIFF
--- a/src/main/java/com/example/walletledger/controller/WalletCommandController.java
+++ b/src/main/java/com/example/walletledger/controller/WalletCommandController.java
@@ -1,0 +1,84 @@
+package com.example.walletledger.controller;
+
+import com.example.walletledger.domain.transaction.WalletTransaction;
+import com.example.walletledger.domain.wallet.Wallet;
+import com.example.walletledger.service.WalletLedgerService;
+import com.example.walletledger.service.dto.CreateWalletCommand;
+import com.example.walletledger.service.dto.MoneyCommand;
+import com.example.walletledger.service.dto.TransferCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class WalletCommandController {
+
+    private final WalletLedgerService walletLedgerService;
+
+    public WalletCommandController(WalletLedgerService walletLedgerService) {
+        this.walletLedgerService = walletLedgerService;
+    }
+
+    @PostMapping("/wallets")
+    public Wallet createWallet(@Valid @RequestBody CreateWalletRequest request) {
+        return walletLedgerService.createWallet(new CreateWalletCommand(request.memberId(), request.currency()));
+    }
+
+    @PostMapping("/wallets/{walletId}/deposit")
+    public WalletTransaction deposit(@PathVariable Long walletId,
+                                     @RequestHeader("Idempotency-Key") String idempotencyKey,
+                                     @Valid @RequestBody MoneyRequest request) {
+        return walletLedgerService.deposit(new MoneyCommand(walletId, request.amount(), request.description(), idempotencyKey));
+    }
+
+    @PostMapping("/wallets/{walletId}/withdraw")
+    public WalletTransaction withdraw(@PathVariable Long walletId,
+                                      @RequestHeader("Idempotency-Key") String idempotencyKey,
+                                      @Valid @RequestBody MoneyRequest request) {
+        return walletLedgerService.withdraw(new MoneyCommand(walletId, request.amount(), request.description(), idempotencyKey));
+    }
+
+    @PostMapping("/transfers")
+    public WalletTransaction transfer(@RequestHeader("Idempotency-Key") String idempotencyKey,
+                                      @Valid @RequestBody TransferRequest request) {
+        return walletLedgerService.transfer(
+            new TransferCommand(
+                request.fromWalletId(),
+                request.toWalletId(),
+                request.amount(),
+                request.description(),
+                idempotencyKey
+            )
+        );
+    }
+
+    public record CreateWalletRequest(
+        @NotNull Long memberId,
+        String currency
+    ) {
+    }
+
+    public record MoneyRequest(
+        @NotNull @Positive BigDecimal amount,
+        String description
+    ) {
+    }
+
+    public record TransferRequest(
+        @NotNull Long fromWalletId,
+        @NotNull Long toWalletId,
+        @NotNull @Positive BigDecimal amount,
+        @NotBlank String description
+    ) {
+    }
+}
+

--- a/src/main/java/com/example/walletledger/infrastructure/idempotency/IdempotencyCacheService.java
+++ b/src/main/java/com/example/walletledger/infrastructure/idempotency/IdempotencyCacheService.java
@@ -1,0 +1,11 @@
+package com.example.walletledger.infrastructure.idempotency;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface IdempotencyCacheService {
+    void save(String key, String value, Duration ttl);
+
+    Optional<String> get(String key);
+}
+

--- a/src/main/java/com/example/walletledger/infrastructure/idempotency/RedisIdempotencyCacheService.java
+++ b/src/main/java/com/example/walletledger/infrastructure/idempotency/RedisIdempotencyCacheService.java
@@ -1,0 +1,27 @@
+package com.example.walletledger.infrastructure.idempotency;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisIdempotencyCacheService implements IdempotencyCacheService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public RedisIdempotencyCacheService(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    @Override
+    public void save(String key, String value, Duration ttl) {
+        stringRedisTemplate.opsForValue().set(key, value, ttl);
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(key));
+    }
+}
+


### PR DESCRIPTION
## 제목
<!-- 예: feat(service): 지갑 생성/입금/출금/이체 핵심 서비스 구현 -->

## 변경 목적
<!-- 이 PR이 왜 필요한지 2~4줄로 작성 -->
- 핵심 서비스 유스케이스를 HTTP API로 노출한다.
- Redis 기반 멱등성 캐시 확장을 위한 인프라 스켈레톤을 추가한다.

## 주요 변경사항
<!-- 핵심 변경을 불릿으로 -->
- WalletCommandController 추가
- 지갑 생성/입금/출금/이체 엔드포인트 연결
- 요청 DTO 검증(@Valid, @Positive, @NotNull) 반영
- IdempotencyCacheService, RedisIdempotencyCacheService 추가

## 설계/구현 포인트
<!-- 면접/포트폴리오에서 설명 가능한 의사결정 위주 -->
- 트랜잭션 경계: 컨트롤러는 서비스 호출만 담당, 경계는 서비스 계층 유지
- 동시성 제어: API 계층은 무상태, 동시성 책임은 서비스+DB 락으로 위임
- 데이터 정합성: 컨트롤러에 비즈니스 로직을 두지 않고 오케스트레이션만 수행
- 예외 처리 전략: 글로벌 핸들러로 일관 응답
- 확장 고려사항: Redis 캐시 서비스로 멱등 결과 재반환 전략 확장 가능

## API/스키마 영향도
- [x] API 스펙 변경 있음
- [ ] DB 스키마 변경 있음
- [ ] 없음

### API 변경 내용
<!-- 엔드포인트 추가/변경/삭제 요약 -->
- `POST /api/v1/wallets`
- `POST /api/v1/wallets/{walletId}/deposit`
- `POST /api/v1/wallets/{walletId}/withdraw`
- `POST /api/v1/transfers`

### 테스트 결과 요약
<!-- 실제로 확인한 결과를 짧게 -->
- API-서비스 wiring 및 요청 유효성 검증 정적 점검 완료

## 리뷰 포인트
<!-- 리뷰어가 특히 봐야 할 부분 -->
- 컨트롤러가 비즈니스 로직 없이 얇게 유지되는지
- 요청/헤더(`Idempotency-Key`) 매핑 일관성
- Redis 인프라 스켈레톤의 책임 경계 적절성

## 체크리스트
- [x] 커밋 메시지를 컨벤션(`feat/chore/fix`)에 맞췄다
- [x] 비즈니스 로직이 Controller가 아닌 Service/Domain에 위치한다
- [x] 예외 코드/메시지가 일관된다
- [x] 주석(JavaDoc/인라인)은 한국어로 작성했다
- [x] 민감정보(비밀번호/키) 하드코딩이 없다
- [x] 문서(README/API 설명) 반영이 필요하면 반영했다

## 관련 이슈
<!-- 예: closes #12 -->
- 
